### PR TITLE
Specify audience-network-sdk:4.28.2

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-facebook-audnet-sdk"
-        version="4.26.2">
+        version="4.28.2">
       
   <name>Facebook AudienceNetwork SDK for Cordova</name>
   <description>Add Facebook SDK to Cordova porject, as dependency for other plugins</description>
@@ -20,13 +20,13 @@
 
   <platform name="android">
     <framework src="fb-adsdk.gradle" custom="true" type="gradleReference" />
-    <framework src="com.facebook.android:audience-network-sdk:4.+"/>
+    <framework src="com.facebook.android:audience-network-sdk:4.28.2"/>
     <framework src="com.google.android.gms:play-services-ads:+"/>
   </platform>
      
   <platform name="amazon-fireos">
     <framework src="fb-adsdk.gradle" custom="true" type="gradleReference" />
-    <framework src="com.facebook.android:audience-network-sdk:4.+"/>
+    <framework src="com.facebook.android:audience-network-sdk:4.28.2"/>
     <framework src="com.google.android.gms:play-services-ads:+"/>
   </platform>
 


### PR DESCRIPTION
I'm proposing this file change so that it will be compatible with the latest version of cordova-plugin-facebookads (4.23.2) as a stop-gap to address issue https://github.com/floatinghotpot/cordova-plugin-facebookads/issues/102

In addition to this, I propose an additional release to target the latest version of the Audience Network Android SDK ([4.99.0](https://developers.facebook.com/docs/audience-network/download#android)) once https://github.com/floatinghotpot/cordova-plugin-facebookads/issues/102 is resolved